### PR TITLE
Fixed app crashing

### DIFF
--- a/app/src/main/java/edu/temple/namelist/CustomAdapter.kt
+++ b/app/src/main/java/edu/temple/namelist/CustomAdapter.kt
@@ -10,7 +10,7 @@ class CustomAdapter(private val names: List<String>, private val context: Contex
 
     // How many items are in the collection
     override fun getCount(): Int {
-        return 5
+        return names.size
     }
 
     // Fetch an item from the collection

--- a/app/src/main/java/edu/temple/namelist/MainActivity.kt
+++ b/app/src/main/java/edu/temple/namelist/MainActivity.kt
@@ -12,7 +12,7 @@ import android.widget.TextView
 
 class MainActivity : AppCompatActivity() {
 
-    lateinit var names: List<String>
+    lateinit var names: MutableList<String>
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)


### PR DESCRIPTION
Fixed getCount() to return the total number of names in the list, and also declared names as a MutableList instead of a List